### PR TITLE
Fix typo and strip trailing whitespace.

### DIFF
--- a/docs/ehr_extract/master.adoc
+++ b/docs/ehr_extract/master.adoc
@@ -49,7 +49,7 @@ include::master00-amendment_record.adoc[leveloffset=+1]
 The work reported in this paper has been funded in by the following organisations:
 
 * University College London - Centre for Health Informatics and Multi-professional Education (CHIME);
-* Ocean Informatics; 
+* Ocean Informatics;
 
 Special thanks to David Ingram, Emeritus Professor of Health Informatics at UCL, who provided a vision and collegial working environment ever since the days of GEHR (1992).
 

--- a/docs/ehr_extract/master00-amendment_record.adoc
+++ b/docs/ehr_extract/master00-amendment_record.adoc
@@ -50,7 +50,7 @@
 
 4+^h|*R E L E A S E{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}1.0.1*
 
-|2.0 
+|2.0
 |{spec_tickets}/SPEC-189[SPEC-189^]. Add `LOCATABLE`.`_parent_`. New invariant in `EHR_EXTRACT`.
 |T Beale
 |20 Feb 2007
@@ -69,37 +69,37 @@
 4+^h|*R E L E A S E{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}0.95*
 
 |1.3.5
-|{spec_tickets}/SPEC-118[SPEC-118^]. Make package names lower case. 
-|T Beale 
+|{spec_tickets}/SPEC-118[SPEC-118^]. Make package names lower case.
+|T Beale
 |10 Dec 2004
 
 4+^h|*R E L E A S E{nbsp}{nbsp}{nbsp}{nbsp}{nbsp}0.9*
 
-|1.3.4 
+|1.3.4
 |{spec_tickets}/SPEC-41[SPEC-41^]. Visually differentiate primitive types in openEHR documents.
-|D Lloyd 
+|D Lloyd
 |04 Oct 2003
 
-|1.3.3 
+|1.3.3
 |{spec_tickets}/SPEC-13[SPEC-13^]. Change key class names, according to CEN ENV 13606.
-|S Heard, 
- D Kalra, 
- D Lloyd, 
+|S Heard,
+ D Kalra,
+ D Lloyd,
  T Beale
 |15 Sep 2003
 
-|1.3.2 
+|1.3.2
 |{spec_tickets}/SPEC-3[SPEC-3^], {spec_tickets}/SPEC-4[SPEC-4^] (changes to versioning and LOCATABLE).  `MESSAGE_CONTENT` now inherits from `LOCATABLE`.
 |T Beale,
  Z Tun
 |18 Mar 2003
 
-|1.3.1 
+|1.3.1
 |Formally validated using ISE Eiffel 5.2. Revised structure of `MESSAGE` class to align better with CEN 13606-4. Renamed `EHR_EXTRACT`.`_hca_authorising_` to `_originator_`, similar to 13606.
-|T Beale 
+|T Beale
 |26 Feb 2003
 
-|1.3 
+|1.3
 |Changes post CEN WG meeting Rome Feb 2003. Added attestations to `X_TRANSACTION` class. Significantly improved documentation of requirements, comparison to CEN 13606-4.
 |T Beale, +
  S Heard, +
@@ -107,31 +107,31 @@
  D Lloyd
 |07 Feb 2003
 
-|1.2.2 
-|Minor corrections to diagrams and class definitions. 
-|Z Tun 
+|1.2.2
+|Minor corrections to diagrams and class definitions.
+|Z Tun
 |08 Jan 2003
 
-|1.2.1 
+|1.2.1
 |Added senders_reference to conform to CEN 13606-4:2000 section 7.4.
-|T Beale 
+|T Beale
 |04 Jan 2003
 
-|1.2 
-|Rewritten and restructured as two packages. 
-|T Beale 
+|1.2
+|Rewritten and restructured as two packages.
+|T Beale
 |07 Nov 2002
 
-|1.1 
+|1.1
 |Moved part of `EHR_EXTRACT` into `MESSAGE`. Allow for multilevel archetypable Folder structures.
 |T Beale, +
  D Kalra, +
  D Lloyd
 |07 Oct 2002
 
-|1.0 
-|Taken from EHR RM. 
-|T Beale 
+|1.0
+|Taken from EHR RM.
+|T Beale
 |07 Oct 2002
 
 |===

--- a/docs/ehr_extract/master04-common_package.adoc
+++ b/docs/ehr_extract/master04-common_package.adoc
@@ -107,7 +107,7 @@ latter are specified using the criteria attribute.
 ==== Version Specification
 
 An Extract request in its simplest form has no version specification, corresponding to the assumption
-of 'latest available version' for each matched item. However, in some situations there is a need to rettrieve
+of 'latest available version' for each matched item. However, in some situations there is a need to retrieve
 previous versions, or information about versions. The version specification part of the Extract
 request allows this to be done. The possibilities available are as follows.
 

--- a/docs/ehr_extract/master05-openehr_extract_package.adoc
+++ b/docs/ehr_extract/master05-openehr_extract_package.adoc
@@ -9,7 +9,7 @@ The `rm.extract.openehr_extract` package defines an openEHR-specific variant of 
 EHR form of the class. This class is further subtyped via binding to non-generic types corresponding
 to the top-level object types of the openEHR EHR.
 
-The UML diagram below illustrates the `rm.extract.openehr_extract` package. 
+The UML diagram below illustrates the `rm.extract.openehr_extract` package.
 
 [.text-center]
 .rm.extract.openehr_extract Package
@@ -24,7 +24,7 @@ image::{diagrams_uri}/typical_extract_structure.png[id=typical_extract_structure
 == Design
 
 === openEHR Extract Item
- 
+
 Items from an openEHR sytem included in an EHR Extract are always top-level objects (Composition,
 Directory, `EHR_EXTRACT`, `PARTY`, etc, and descendants) are expressed in the serialisable form of
 descendants of `X_VERSIONED_OBJECT<T>`. This type provides a standard interoperable way to serialise all or part of `VERSIONED_OBJECTs` for lossless transmission between systems, regardless of the

--- a/docs/ehr_extract/master09-semantics.adoc
+++ b/docs/ehr_extract/master09-semantics.adoc
@@ -78,7 +78,7 @@ The algorithm is as follows.
 ** for each instance of `DV_MULTIMEDIA` encountered, include or exclude the content
 referred to by the uri or data attributes, according to the `_include_multimedia_` flag;
 ** according to the value of `_follow_links_`, for each instance of `DV_LINK` encountered (only from/to Archetyped entities):
-* follow the links recursively. For each link: create an `X_VERSIONED_COMPOSITION`; 
+* follow the links recursively. For each link: create an `X_VERSIONED_COMPOSITION`;
 set `_is_primary_` = False, write the path and write the target Compositions in the extract if not already there;
 * create the `DV_LINK` objects so that their paths refer correctly to the Compositions in the Extract;
 


### PR DESCRIPTION
Fixes a small typo and removes some trailing whitespace from the docs.