### PR TITLE
Fix mistake in reference to PARTY_RELATED

### DIFF
--- a/docs/common/master04-generic_package.adoc
+++ b/docs/common/master04-generic_package.adoc
@@ -22,7 +22,7 @@ The `PARTY_PROXY` class and subtypes model references to parties based on these 
 
 The two subtypes correspond to the mutually distinct categories of the 'subject of the record', known as the 'self' party in openEHR, and any other party. Whenever the record subject has to be referred to in the record, an instance of `PARTY_SELF` is used, while `PARTY_IDENTIFIED` is used for all other situations. The latter class provides for optional human-readable names and formal identifiers, each keyed by purpose or meaning.
 
-The `RELATED_PARTY` type is used whenever the relationship of the party to the record subject is required. Relationships are coded and include familial ones ('mother', 'uncle', etc) as well as relationships like 'donor', 'travelling companion' and so on.
+The `PARTY_RELATED` type is used whenever the relationship of the party to the record subject is required. Relationships are coded and include familial ones ('mother', 'uncle', etc) as well as relationships like 'donor', 'travelling companion' and so on.
 
 ==== PARTY_SELF and Referring to the Patient from the EHR
 


### PR DESCRIPTION
the common model contained a reference to RELATED_PARTY instead of PARTY_RELATED. That appears to be incorrect. Note that it still appears a couple of times in the change log.