### PR TITLE
Normalize asterisk HTML entities in BMM and class tables

### DIFF
--- a/computable/BMM/openehr_rm_1.2.0.bmm.json
+++ b/computable/BMM/openehr_rm_1.2.0.bmm.json
@@ -3528,7 +3528,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this Proportion and `_factor_`.",
                     "parameters": {
@@ -3737,7 +3737,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this Amount and `_factor_`.",
                     "parameters": {
@@ -3903,7 +3903,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this `DV_QUANTITY` and `_factor_`.",
                     "parameters": {
@@ -4051,7 +4051,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this `DV_COUNT` and `_factor_`.",
                     "parameters": {
@@ -4356,7 +4356,7 @@
                 "multiply": {
                     "name": "multiply",
                     "aliases": [
-                        "&#42;"
+                        "*"
                     ],
                     "documentation": "Product of this Duration and `_factor_`.",
                     "parameters": {

--- a/docs/UML/classes/org.openehr.rm.composition.activity.adoc
+++ b/docs/UML/classes/org.openehr.rm.composition.activity.adoc
@@ -28,7 +28,7 @@ h|*1..1*
 |*action_archetype_id*: `link:/releases/BASE/{base_release}/foundation_types.html#_string_class[String^]`
 a|Perl-compliant regular expression pattern, enclosed in  '//' delimiters, indicating the valid identifiers of archetypes for Actions corresponding to this Activity specification. 
 
-Defaults to  `/.&#42;/`, meaning any archetype.
+Defaults to  `/.*/`, meaning any archetype.
 
 h|*1..1*
 |*description*: `link:/releases/RM/{rm_release}/data_structures.html#_item_structure_class[ITEM_STRUCTURE^]`

--- a/docs/UML/classes/org.openehr.rm.data_types.dv_amount.adoc
+++ b/docs/UML/classes/org.openehr.rm.data_types.dv_amount.adoc
@@ -70,7 +70,7 @@ other: `<<_dv_amount_class,DV_AMOUNT>>[1]` +
 a|Return True if this `DV_AMOUNT` is considered equal to `_other_`.
 
 h|*1..1*
-|*multiply* __alias__ "&#42;" ( +
+|*multiply* __alias__ "*" ( +
 factor: `link:/releases/BASE/{base_release}/foundation_types.html#_real_class[Real^][1]` +
 ): `<<_dv_amount_class,DV_AMOUNT>>`
 a|Product of this Amount and `_factor_`.

--- a/docs/UML/classes/org.openehr.rm.data_types.dv_count.adoc
+++ b/docs/UML/classes/org.openehr.rm.data_types.dv_count.adoc
@@ -51,7 +51,7 @@ a|Difference of this `DV_COUNT` and `_other_`.
 
 h|*1..1 +
 (redefined)*
-|*multiply* __alias__ "&#42;" ( +
+|*multiply* __alias__ "*" ( +
 factor: `link:/releases/BASE/{base_release}/foundation_types.html#_real_class[Real^][1]` +
 ): `<<_dv_count_class,DV_COUNT>>`
 a|Product of this `DV_COUNT` and `_factor_`.

--- a/docs/UML/classes/org.openehr.rm.data_types.dv_duration.adoc
+++ b/docs/UML/classes/org.openehr.rm.data_types.dv_duration.adoc
@@ -46,7 +46,7 @@ a|Difference of this Duration and `_other_`.
 
 h|*1..1 +
 (redefined)*
-|*multiply* __alias__ "&#42;" ( +
+|*multiply* __alias__ "*" ( +
 factor: `link:/releases/BASE/{base_release}/foundation_types.html#_real_class[Real^][1]` +
 ): `<<_dv_duration_class,DV_DURATION>>`
 a|Product of this Duration and `_factor_`.

--- a/docs/UML/classes/org.openehr.rm.data_types.dv_proportion.adoc
+++ b/docs/UML/classes/org.openehr.rm.data_types.dv_proportion.adoc
@@ -81,7 +81,7 @@ a|Return True if this `DV_AMOUNT` is considered equal to `_other_`.
 
 h|*1..1 +
 (redefined)*
-|*multiply* __alias__ "&#42;" ( +
+|*multiply* __alias__ "*" ( +
 factor: `link:/releases/BASE/{base_release}/foundation_types.html#_real_class[Real^][1]` +
 ): `<<_dv_proportion_class,DV_PROPORTION>>`
 a|Product of this Proportion and `_factor_`.

--- a/docs/UML/classes/org.openehr.rm.data_types.dv_quantity.adoc
+++ b/docs/UML/classes/org.openehr.rm.data_types.dv_quantity.adoc
@@ -80,7 +80,7 @@ a|Difference of this `DV_QUANTITY` and `_other_`.
 
 h|*1..1 +
 (redefined)*
-|*multiply* __alias__ "&#42;" ( +
+|*multiply* __alias__ "*" ( +
 factor: `link:/releases/BASE/{base_release}/foundation_types.html#_real_class[Real^][1]` +
 ): `<<_dv_quantity_class,DV_QUANTITY>>`
 a|Product of this `DV_QUANTITY` and `_factor_`.


### PR DESCRIPTION
## What

Replace the pre-escaped `&#42;` HTML entity with the literal `*` character in `computable/BMM/openehr_rm_1.2.0.bmm.json` — the five `multiply` operator aliases on `DV_AMOUNT`, `DV_COUNT`, `DV_DURATION`, `DV_PROPORTION`, `DV_QUANTITY`. The model should carry the plain character; output-format escaping is the publisher's job.

The affected `docs/UML/classes` tables are regenerated from the BMM:
- the five `multiply` tables — alias now renders as `"*"`;
- `activity.adoc` — its regex-any default `/.*/` was previously escaped to `/.&#42;/` by the publisher even though the BMM documentation already held a literal `*`.

Mirrors the equivalent normalization in specifications-BASE.

## Notes

- All changes are asterisk-only; verified no other content drift.
- `resource_description.adoc` was **deliberately not regenerated** — doing so surfaced unrelated publisher-version drift (generic-type comma spacing, default-value formatting) that is out of scope here.
- The five `multiply` tables are BMM-driven and stable. `activity.adoc`'s single-asterisk normalization depends on the [bmm-publisher asterisk-escaping fix](https://github.com/openEHR/bmm-publisher/pull/18); regenerating with the currently-released publisher would re-escape that one line.
- `.html` build artifacts will reflect this on the next `spec_publish.sh RM` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)